### PR TITLE
Disabling nametag by default so that name can be applied to villagers with professions.

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,10 +23,12 @@ database:
 IgnoreCitizens: true
 IgnoreShopkeepers: true
 
-# Ignore interactions when the player is holding one of these item types (e.g. spawn_egg)
+# Ignore interactions when the player is holding one of these item types (e.g. spawn_egg, name_tag)
+# Without disabling nametag, you cannot rename a villager with a profession. Do not remove name_tag if you want to retain vanilla behavior. 
 # Ghast spawn egg is added to add compatibility with Safarinet plugin. If your server doesn't give ghast egg to noromal players you can ignore it.
 # Set to [] to disable this feature.
-IgnoreHeldItems: 
+IgnoreHeldItems:
+  - "name_tag"
   - "ghast_spawn_egg"
 
 # Add world names for worlds that you want to completely disable ALL villager trading. Set to [] to disable this feature.


### PR DESCRIPTION
Without this nametag can't be applied to a villager with profession. This should be included by default to retain vanilla  behavior.